### PR TITLE
Improve 404 handler comment

### DIFF
--- a/src/webserver.h
+++ b/src/webserver.h
@@ -3,7 +3,7 @@
 
 extern AsyncWebServer server;
 
-void notFound(AsyncWebServerRequest *request); // Optional: für 404
+void notFound(AsyncWebServerRequest *request); // Handler für 404-Fehlerseiten
 
 namespace WebServer
 {


### PR DESCRIPTION
## Summary
- clarify the purpose of `notFound()` in the web server header

## Testing
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481e1dbdcc83329602acbc222853b1