### PR TITLE
Add unit test for schedule

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -27,3 +27,10 @@ lib_deps =
     ArduinoOTA
     EEPROM
     WiFi
+
+[env:native]
+platform = native
+build_flags = -Itest/stubs
+src_filter = +<src/schedule.cpp>
+test_build_src = yes
+

--- a/test/stubs/Arduino.h
+++ b/test/stubs/Arduino.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <stdint.h>
+#include <string>
+
+extern unsigned long testMillis;
+static inline unsigned long millis() { return testMillis; }
+
+using String = std::string;

--- a/test/stubs/EEPROM.h
+++ b/test/stubs/EEPROM.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <cstdint>
+
+class EEPROMClass {
+public:
+    int readInt(int) { return 0; }
+    void writeInt(int, int) {}
+    void writeBool(int, bool) {}
+    uint8_t read(int) { return 0; }
+    void commit() {}
+};
+
+extern EEPROMClass EEPROM;

--- a/test/stubs/logging.h
+++ b/test/stubs/logging.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <string>
+
+namespace Log {
+    inline void add(const std::string&) {}
+    inline void add(const char*) {}
+    inline std::string get() { return ""; }
+    inline void clearLogFile() {}
+}
+
+#define TRACE_STACK()

--- a/test/stubs/servo_control.h
+++ b/test/stubs/servo_control.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "Arduino.h"
+#include "config.h"
+
+namespace ServoControl {
+    extern int lastPosition;
+    inline void init() {}
+    inline void move(int position) { lastPosition = position; }
+    inline int getCurrentPosition() { return lastPosition; }
+    inline String getPositionName(int position) { return ""; }
+    inline bool isPushEnabled() { return true; }
+    inline void setPushEnabled(bool enabled) {}
+}

--- a/test/test_schedule.cpp
+++ b/test/test_schedule.cpp
@@ -1,0 +1,52 @@
+#include <unity.h>
+#include "schedule.h"
+#include "config.h"
+#include "servo_control.h"
+#include <time.h>
+
+unsigned long testMillis = 0;
+int ServoControl::lastPosition = -1;
+EEPROMClass EEPROM; // from stub
+
+static struct tm fakeTime;
+
+extern "C" bool getLocalTime(struct tm *info)
+{
+    if(!info) return false;
+    *info = fakeTime;
+    return true;
+}
+
+void setFakeTime(int hh, int mm)
+{
+    fakeTime = {};
+    fakeTime.tm_hour = hh;
+    fakeTime.tm_min = mm;
+}
+
+void test_schedule_runs_and_moves_servo()
+{
+    // prepare schedule
+    int *times = const_cast<int *>(Schedule::getTimes());
+    int *positions = const_cast<int *>(Schedule::getPositions());
+    times[0] = 1000;      // 10:00
+    positions[0] = SAUNA;
+    times[1] = 1200; positions[1] = AUS;
+    times[2] = 1600; positions[2] = AUS;
+    times[3] = 2000; positions[3] = AUS;
+
+    ServoControl::lastPosition = -1;
+    testMillis = 61000;  // ensure enough time passed
+    setFakeTime(10, 0);
+
+    Schedule::checkAndRun();
+
+    TEST_ASSERT_EQUAL(SAUNA, ServoControl::lastPosition);
+}
+
+int main(int argc, char **argv)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_schedule_runs_and_moves_servo);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- add unit test `test_schedule.cpp` for `Schedule::checkAndRun`
- provide stub headers for Arduino dependent modules
- configure new `native` environment in `platformio.ini` for running tests

## Testing
- `pio test -e native` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481e70ffa88332b74bdcf56dda194e